### PR TITLE
Various small fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,12 @@ Format Nix files with:
 nix fmt
 ```
 
+The flake formatter uses `treefmt-nix` to run the official Nix formatter.
+
 Run evaluation checks without building the C++ packages:
 
 ```shell
 nix flake check --no-build --all-systems
-```
-
-Run only the formatting check:
-
-```shell
-nix build .#checks.$(nix eval --raw --impure --expr builtins.currentSystem).formatting --no-link
 ```
 
 ## Silent Payments Load Benchmark

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ LIBBITCOIN_LOCAL_ROOT=~/libbitcoin nix build --impure .#local-libbitcoin-server 
 
 `LIBBITCOIN_LOCAL_ROOT` should point at the directory that contains `repos/`.
 
+Run the default package directly with:
+
+```shell
+nix run . -- --settings
+```
+
 Available packages:
 
 - `libbitcoin-system`
@@ -37,6 +43,8 @@ The package set also contains `secp256k1CmakeConfig`, a small CMake package
 config shim for nixpkgs' `secp256k1`. nixpkgs already provides the library, but
 libbitcoin's CMake files expect `find_package(libsecp256k1)` and the imported
 target `libsecp256k1::secp256k1`.
+
+Consumers that need the full package set can use `legacyPackages.${system}`.
 
 ## NixOS
 

--- a/examples/nixos-configuration.nix
+++ b/examples/nixos-configuration.nix
@@ -1,4 +1,5 @@
-{inputs, ...}: {
+{ inputs, ... }:
+{
   imports = [
     inputs.nix-libbitcoin.nixosModules.default
   ];

--- a/flake.nix
+++ b/flake.nix
@@ -17,11 +17,13 @@
       ...
     }:
     let
+      lib = nixpkgs.lib;
       supportedSystems = [
         "x86_64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
       ];
+      forAllSystems = lib.genAttrs supportedSystems;
 
       perSystem =
         system:
@@ -70,8 +72,6 @@
               }
             else
               { };
-        in
-        {
           packages = {
             inherit (libbitcoinPackages)
               ultrafastSecp256k1
@@ -95,7 +95,17 @@
             local-libbitcoin-node-tests = localLibbitcoinTestPackages.libbitcoin-node;
             local-libbitcoin-server-tests = localLibbitcoinTestPackages.libbitcoin-server;
           };
+          serverApp = {
+            type = "app";
+            program = lib.getExe packages.libbitcoin-server;
+            meta.description = "Run libbitcoin-server";
+          };
+        in
+        {
+          inherit packages;
           apps = {
+            default = serverApp;
+            libbitcoin-server = serverApp;
             sp-load = {
               type = "app";
               program = toString (
@@ -110,15 +120,17 @@
             formatting = treefmtEval.config.build.check self;
           };
           formatter = treefmtEval.config.build.wrapper;
+          legacyPackages = libbitcoinPackages;
         };
 
-      allSystems = nixpkgs.lib.genAttrs supportedSystems perSystem;
+      allSystems = forAllSystems perSystem;
     in
     {
-      packages = nixpkgs.lib.mapAttrs (_: v: v.packages) allSystems;
-      apps = nixpkgs.lib.mapAttrs (_: v: v.apps) allSystems;
+      packages = lib.mapAttrs (_: v: v.packages) allSystems;
+      apps = lib.mapAttrs (_: v: v.apps) allSystems;
       checks = nixpkgs.lib.mapAttrs (_: v: v.checks) allSystems;
-      formatter = nixpkgs.lib.mapAttrs (_: v: v.formatter) allSystems;
+      legacyPackages = lib.mapAttrs (_: v: v.legacyPackages) allSystems;
+      formatter = lib.mapAttrs (_: v: v.formatter) allSystems;
       overlays.default = final: prev: {
         libbitcoinPackages = final.callPackage ./pkgs/libbitcoin { };
         inherit (final.libbitcoinPackages)

--- a/flake.nix
+++ b/flake.nix
@@ -9,102 +9,129 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    treefmt-nix,
-  }: let
-    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-darwin"];
+  outputs =
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+      ...
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
 
-    perSystem = system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      libbitcoinPackages = pkgs.callPackage ./pkgs/libbitcoin {};
-      localRootEnv = builtins.getEnv "LIBBITCOIN_LOCAL_ROOT";
-      hasLocalRoot = localRootEnv != "";
-      localRoot =
-        if hasLocalRoot
-        then /. + localRootEnv
-        else null;
-      ccacheEnv = builtins.getEnv "LIBBITCOIN_CCACHE";
-      useCcache = ccacheEnv == "1" || ccacheEnv == "true";
-      ccacheDirEnv = builtins.getEnv "LIBBITCOIN_CCACHE_DIR";
-      ccacheDir =
-        if ccacheDirEnv == ""
-        then "/var/cache/ccache"
-        else ccacheDirEnv;
-      cudaEnv = builtins.getEnv "LIBBITCOIN_CUDA";
-      withCuda = cudaEnv == "1" || cudaEnv == "true";
-      xcpuEnv = builtins.getEnv "LIBBITCOIN_XCPU";
-      enableXcpu = xcpuEnv == "1" || xcpuEnv == "true";
-      localLibbitcoinPackages =
-        if hasLocalRoot
-        then
-          pkgs.callPackage ./pkgs/libbitcoin {
-            inherit localRoot withCuda enableXcpu useCcache ccacheDir;
-          }
-        else {};
-      localLibbitcoinTestPackages =
-        if hasLocalRoot
-        then
-          pkgs.callPackage ./pkgs/libbitcoin {
-            inherit localRoot withCuda enableXcpu useCcache ccacheDir;
-            withTests = true;
-          }
-        else {};
-      treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-    in {
-      packages =
+      perSystem =
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          libbitcoinPackages = pkgs.callPackage ./pkgs/libbitcoin { };
+          localRootEnv = builtins.getEnv "LIBBITCOIN_LOCAL_ROOT";
+          hasLocalRoot = localRootEnv != "";
+          localRoot = if hasLocalRoot then /. + localRootEnv else null;
+          ccacheEnv = builtins.getEnv "LIBBITCOIN_CCACHE";
+          useCcache = ccacheEnv == "1" || ccacheEnv == "true";
+          ccacheDirEnv = builtins.getEnv "LIBBITCOIN_CCACHE_DIR";
+          ccacheDir = if ccacheDirEnv == "" then "/var/cache/ccache" else ccacheDirEnv;
+          cudaEnv = builtins.getEnv "LIBBITCOIN_CUDA";
+          withCuda = cudaEnv == "1" || cudaEnv == "true";
+          xcpuEnv = builtins.getEnv "LIBBITCOIN_XCPU";
+          enableXcpu = xcpuEnv == "1" || xcpuEnv == "true";
+          treefmtEval = treefmt-nix.lib.evalModule pkgs {
+            projectRootFile = "flake.nix";
+            programs.nixfmt.enable = true;
+          };
+          localLibbitcoinPackages =
+            if hasLocalRoot then
+              pkgs.callPackage ./pkgs/libbitcoin {
+                inherit
+                  localRoot
+                  withCuda
+                  enableXcpu
+                  useCcache
+                  ccacheDir
+                  ;
+              }
+            else
+              { };
+          localLibbitcoinTestPackages =
+            if hasLocalRoot then
+              pkgs.callPackage ./pkgs/libbitcoin {
+                inherit
+                  localRoot
+                  withCuda
+                  enableXcpu
+                  useCcache
+                  ccacheDir
+                  ;
+                withTests = true;
+              }
+            else
+              { };
+        in
         {
-          inherit (libbitcoinPackages) ultrafastSecp256k1 libbitcoin-system libbitcoin-database libbitcoin-network libbitcoin-node libbitcoin-server;
-          default = libbitcoinPackages.libbitcoin-server;
-        }
-        // nixpkgs.lib.optionalAttrs hasLocalRoot {
-          local-libbitcoin-system = localLibbitcoinPackages.libbitcoin-system;
-          local-libbitcoin-database = localLibbitcoinPackages.libbitcoin-database;
-          local-libbitcoin-network = localLibbitcoinPackages.libbitcoin-network;
-          local-libbitcoin-node = localLibbitcoinPackages.libbitcoin-node;
-          local-libbitcoin-server = localLibbitcoinPackages.libbitcoin-server;
-          local-libbitcoin-system-tests = localLibbitcoinTestPackages.libbitcoin-system;
-          local-libbitcoin-database-tests = localLibbitcoinTestPackages.libbitcoin-database;
-          local-libbitcoin-network-tests = localLibbitcoinTestPackages.libbitcoin-network;
-          local-libbitcoin-node-tests = localLibbitcoinTestPackages.libbitcoin-node;
-          local-libbitcoin-server-tests = localLibbitcoinTestPackages.libbitcoin-server;
+          packages = {
+            inherit (libbitcoinPackages)
+              ultrafastSecp256k1
+              libbitcoin-system
+              libbitcoin-database
+              libbitcoin-network
+              libbitcoin-node
+              libbitcoin-server
+              ;
+            default = libbitcoinPackages.libbitcoin-server;
+          }
+          // nixpkgs.lib.optionalAttrs hasLocalRoot {
+            local-libbitcoin-system = localLibbitcoinPackages.libbitcoin-system;
+            local-libbitcoin-database = localLibbitcoinPackages.libbitcoin-database;
+            local-libbitcoin-network = localLibbitcoinPackages.libbitcoin-network;
+            local-libbitcoin-node = localLibbitcoinPackages.libbitcoin-node;
+            local-libbitcoin-server = localLibbitcoinPackages.libbitcoin-server;
+            local-libbitcoin-system-tests = localLibbitcoinTestPackages.libbitcoin-system;
+            local-libbitcoin-database-tests = localLibbitcoinTestPackages.libbitcoin-database;
+            local-libbitcoin-network-tests = localLibbitcoinTestPackages.libbitcoin-network;
+            local-libbitcoin-node-tests = localLibbitcoinTestPackages.libbitcoin-node;
+            local-libbitcoin-server-tests = localLibbitcoinTestPackages.libbitcoin-server;
+          };
+          apps = {
+            sp-load = {
+              type = "app";
+              program = toString (
+                pkgs.writeShellScript "sp-load" ''
+                  exec ${pkgs.python3}/bin/python3 ${./bench/silentpayments_electrum_load.py} "$@"
+                ''
+              );
+              meta.description = "Run a Silent Payments Electrum JSON-RPC load benchmark";
+            };
+          };
+          checks = {
+            formatting = treefmtEval.config.build.check self;
+          };
+          formatter = treefmtEval.config.build.wrapper;
         };
-      checks = {
-        formatting = treefmtEval.config.build.check self;
-      };
-      apps = {
-        sp-load = {
-          type = "app";
-          program = toString (pkgs.writeShellScript "sp-load" ''
-            exec ${pkgs.python3}/bin/python3 ${./bench/silentpayments_electrum_load.py} "$@"
-          '');
-          meta.description = "Run a Silent Payments Electrum JSON-RPC load benchmark";
-        };
-      };
-      formatter = treefmtEval.config.build.wrapper;
-    };
 
-    allSystems = nixpkgs.lib.genAttrs supportedSystems perSystem;
-  in {
-    packages = nixpkgs.lib.mapAttrs (_: v: v.packages) allSystems;
-    apps = nixpkgs.lib.mapAttrs (_: v: v.apps) allSystems;
-    checks = nixpkgs.lib.mapAttrs (_: v: v.checks) allSystems;
-    formatter = nixpkgs.lib.mapAttrs (_: v: v.formatter) allSystems;
-    overlays.default = final: prev: {
-      libbitcoinPackages = final.callPackage ./pkgs/libbitcoin {};
-      inherit
-        (final.libbitcoinPackages)
-        libbitcoin-system
-        libbitcoin-database
-        libbitcoin-network
-        libbitcoin-node
-        libbitcoin-server
-        ;
+      allSystems = nixpkgs.lib.genAttrs supportedSystems perSystem;
+    in
+    {
+      packages = nixpkgs.lib.mapAttrs (_: v: v.packages) allSystems;
+      apps = nixpkgs.lib.mapAttrs (_: v: v.apps) allSystems;
+      checks = nixpkgs.lib.mapAttrs (_: v: v.checks) allSystems;
+      formatter = nixpkgs.lib.mapAttrs (_: v: v.formatter) allSystems;
+      overlays.default = final: prev: {
+        libbitcoinPackages = final.callPackage ./pkgs/libbitcoin { };
+        inherit (final.libbitcoinPackages)
+          libbitcoin-system
+          libbitcoin-database
+          libbitcoin-network
+          libbitcoin-node
+          libbitcoin-server
+          ;
+      };
+      nixosModules = rec {
+        default = libbitcoin-server;
+        libbitcoin-server = ./modules/services/libbitcoin-server.nix;
+      };
     };
-    nixosModules = rec {
-      default = libbitcoin-server;
-      libbitcoin-server = ./modules/services/libbitcoin-server.nix;
-    };
-  };
 }

--- a/modules/services/libbitcoin-server-settings.nix
+++ b/modules/services/libbitcoin-server-settings.nix
@@ -1,13 +1,16 @@
 # Generated from libbitcoin-server src/parser.cpp at commit 1df3db4a653ca56a8785093bc7facee4996796b0.
 # Keep this file in sync when updating the libbitcoin-server source pin.
-{lib}: let
+{ lib }:
+let
   inherit (lib) mkOption types;
-  mkNullable = type: description:
+  mkNullable =
+    type: description:
     mkOption {
       inherit type description;
       default = null;
     };
-in {
+in
+{
   forks = mkOption {
     type = types.submodule {
       options = {
@@ -33,7 +36,7 @@ in {
         scrypt_proof_of_work = mkNullable (types.nullOr types.bool) "Use scrypt hashing for proof of work, defaults to 'false' (hard fork).";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [forks] configuration settings.";
   };
   bitcoin = mkOption {
@@ -64,7 +67,7 @@ in {
         minimum_work = mkNullable (types.nullOr types.str) "The minimum work for any branch to be considered valid, defaults to '000000000000000000000000000000000000000052b2559353df4117b7348b64'.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [bitcoin] configuration settings.";
   };
   network = mkOption {
@@ -78,7 +81,7 @@ in {
         whitelist = mkNullable (types.nullOr (types.listOf types.str)) "IP address to allow, prohibits all others, multiple allowed.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [network] configuration settings.";
   };
   peer = mkOption {
@@ -107,7 +110,7 @@ in {
         path = mkNullable (types.nullOr (types.either types.path types.str)) "The peer address cache file directory, defaults to empty.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [peer] configuration settings.";
   };
   outbound = mkOption {
@@ -128,7 +131,7 @@ in {
         socks = mkNullable (types.nullOr types.str) "The socks5 proxy endpoint (port required).";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [outbound] configuration settings.";
   };
   inbound = mkOption {
@@ -144,7 +147,7 @@ in {
         self = mkNullable (types.nullOr (types.listOf types.str)) "IP address to advertise, multiple allowed.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [inbound] configuration settings.";
   };
   manual = mkOption {
@@ -160,7 +163,7 @@ in {
         socks = mkNullable (types.nullOr types.str) "The socks5 proxy endpoint (port required).";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [manual] configuration settings.";
   };
   admin = mkOption {
@@ -185,7 +188,7 @@ in {
         default = mkNullable (types.nullOr types.str) "The path of the default source page, defaults to 'index.html'.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [admin] configuration settings.";
   };
   native = mkOption {
@@ -211,7 +214,7 @@ in {
         websocket = mkNullable (types.nullOr types.bool) "Enable websocket interface, defaults to true.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [native] configuration settings.";
   };
   bitcoind = mkOption {
@@ -236,7 +239,7 @@ in {
         allow_opaque_origin = mkNullable (types.nullOr types.bool) "Allow requests from opaque origin (see CORS), multiple allowed, defaults to false.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [bitcoind] configuration settings.";
   };
   electrum = mkOption {
@@ -266,7 +269,7 @@ in {
         more_safe = mkNullable (types.nullOr (types.listOf types.str)) "Advertised secure host:port at which another server can be reached (defaults to empty).";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [electrum] configuration settings.";
   };
   stratum_v1 = mkOption {
@@ -283,7 +286,7 @@ in {
         maximum_request = mkNullable (types.nullOr types.ints.unsigned) "The maximum allowed request size, defaults to '4000000'.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [stratum_v1] configuration settings.";
   };
   stratum_v2 = mkOption {
@@ -297,7 +300,7 @@ in {
         maximum_request = mkNullable (types.nullOr types.ints.unsigned) "The maximum allowed request size, defaults to '4000000'.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [stratum_v2] configuration settings.";
   };
   node = mkOption {
@@ -325,7 +328,7 @@ in {
         warn_dirty_ratio = mkNullable (types.nullOr types.ints.unsigned) "Warn on linux if 'vm.dirty_ratio' is below value, defaults to 90 (0 disables).";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [node] configuration settings.";
   };
   database = mkOption {
@@ -393,7 +396,7 @@ in {
         silent_start_height = mkNullable (types.nullOr types.ints.unsigned) "The first height indexed by the silent table, defaults to the bip341 activation height.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [database] configuration settings.";
   };
   log = mkOption {
@@ -414,7 +417,7 @@ in {
         path = mkNullable (types.nullOr (types.either types.path types.str)) "The log files directory, defaults to empty.";
       };
     };
-    default = {};
+    default = { };
     description = "libbitcoin-server [log] configuration settings.";
   };
 }

--- a/modules/services/libbitcoin-server.nix
+++ b/modules/services/libbitcoin-server.nix
@@ -3,32 +3,38 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.services.libbitcoin-server;
   defaultPackage =
-    pkgs.libbitcoin-server
-    or pkgs.libbitcoinPackages.libbitcoin-server
-    or (pkgs.callPackage ../../pkgs/libbitcoin {}).libbitcoin-server;
-  settingsOptions = import ./libbitcoin-server-settings.nix {inherit lib;};
+    pkgs.libbitcoin-server or pkgs.libbitcoinPackages.libbitcoin-server
+      or (pkgs.callPackage ../../pkgs/libbitcoin { }).libbitcoin-server;
+  settingsOptions = import ./libbitcoin-server-settings.nix { inherit lib; };
 
-  formatValue = value:
-    if lib.isBool value
-    then lib.boolToString value
-    else if lib.isPath value
-    then toString value
-    else toString value;
+  formatValue =
+    value:
+    if lib.isBool value then
+      lib.boolToString value
+    else if lib.isPath value then
+      toString value
+    else
+      toString value;
 
-  renderKey = key: value:
-    if value == null
-    then []
-    else if lib.isList value
-    then map (item: "${key} = ${formatValue item}") value
-    else ["${key} = ${formatValue value}"];
+  renderKey =
+    key: value:
+    if value == null then
+      [ ]
+    else if lib.isList value then
+      map (item: "${key} = ${formatValue item}") value
+    else
+      [ "${key} = ${formatValue value}" ];
 
-  renderSection = name: values: let
-    lines = lib.concatLists (lib.mapAttrsToList renderKey values);
-  in
-    lib.optionalString (lines != []) ''
+  renderSection =
+    name: values:
+    let
+      lines = lib.concatLists (lib.mapAttrsToList renderKey values);
+    in
+    lib.optionalString (lines != [ ]) ''
       [${name}]
       ${lib.concatStringsSep "\n" lines}
     '';
@@ -38,11 +44,9 @@
     ${cfg.extraConfig}
   '';
 
-  configFile =
-    if cfg.configFile == null
-    then generatedConfig
-    else cfg.configFile;
-in {
+  configFile = if cfg.configFile == null then generatedConfig else cfg.configFile;
+in
+{
   options.services.libbitcoin-server = {
     enable = lib.mkEnableOption "libbitcoin-server";
 
@@ -93,10 +97,10 @@ in {
       type = lib.types.submodule {
         options = settingsOptions;
       };
-      default = {};
+      default = { };
       example = {
         database.path = "/var/lib/libbitcoin-server/blockchain";
-        inbound.bind = ["0.0.0.0:8333"];
+        inbound.bind = [ "0.0.0.0:8333" ];
         log.path = "/var/log/libbitcoin-server";
       };
       description = "Typed libbitcoin-server settings rendered as sections and keys.";
@@ -135,13 +139,13 @@ in {
       home = cfg.dataDir;
     };
 
-    users.groups.${cfg.group} = {};
+    users.groups.${cfg.group} = { };
 
     systemd.services.libbitcoin-server = {
       description = "libbitcoin-server";
-      wantedBy = ["multi-user.target"];
-      after = ["network-online.target"];
-      wants = ["network-online.target"];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
 
       serviceConfig = {
         ExecStart = "${lib.getExe cfg.package} --config ${configFile}";
@@ -157,10 +161,13 @@ in {
         PrivateTmp = true;
         ProtectHome = true;
         ProtectSystem = "strict";
-        ReadWritePaths = [cfg.dataDir cfg.logDir];
+        ReadWritePaths = [
+          cfg.dataDir
+          cfg.logDir
+        ];
       };
     };
 
-    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [cfg.p2pPort];
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.p2pPort ];
   };
 }

--- a/pkgs/libbitcoin/common.nix
+++ b/pkgs/libbitcoin/common.nix
@@ -4,10 +4,7 @@
   lib,
   fetchFromGitHub,
   cmake,
-  boost186,
-  secp256k1,
   ultrafastSecp256k1,
-  secp256k1CmakeConfig,
   localRoot ? null,
   localSources ? { },
   withTests ? false,
@@ -74,14 +71,7 @@ in
       sourceRoot = "source/builds/cmake";
 
       nativeBuildInputs = [ cmake ] ++ nativeBuildInputs;
-      buildInputs = [
-        boost186
-        secp256k1
-        secp256k1CmakeConfig
-      ]
-      ++ lib.optionals withUltrafast [ ultrafastSecp256k1 ]
-      ++ buildInputs;
-      propagatedBuildInputs = propagatedBuildInputs;
+      buildInputs = lib.optionals withUltrafast [ ultrafastSecp256k1 ] ++ buildInputs;
       NIX_CFLAGS_COMPILE = lib.optionalString (
         withUltrafast && pname == "libbitcoin-system"
       ) "-DWITH_ULTRAFAST";
@@ -98,6 +88,7 @@ in
       postPatch = lib.optionalString (patchRoot != ".") ''
         popd
       '';
+      inherit propagatedBuildInputs;
 
       cmakeFlags = [
         "-DBUILD_SHARED_LIBS=ON"

--- a/pkgs/libbitcoin/common.nix
+++ b/pkgs/libbitcoin/common.nix
@@ -9,17 +9,17 @@
   ultrafastSecp256k1,
   secp256k1CmakeConfig,
   localRoot ? null,
-  localSources ? {},
+  localSources ? { },
   withTests ? false,
   withUltrafast ? false,
   useCcache ? false,
   ccacheDir ? "/var/cache/ccache",
   ccacheMaxSize ? "50G",
-}: let
+}:
+let
   version = "4.0.0-unstable-2026-05-29";
   buildStdenv =
-    if useCcache
-    then
+    if useCcache then
       ccacheStdenv.override {
         extraConfig = ''
           export CCACHE_COMPRESS=1
@@ -28,78 +28,83 @@
           export CCACHE_UMASK=007
         '';
       }
-    else stdenv;
-  localSource = repo:
-    if builtins.hasAttr repo localSources
-    then localSources.${repo}
-    else if localRoot != null
-    then
+    else
+      stdenv;
+  localSource =
+    repo:
+    if builtins.hasAttr repo localSources then
+      localSources.${repo}
+    else if localRoot != null then
       builtins.path {
         path = localRoot + "/repos/${repo}";
         name = "source";
       }
-    else throw "No local source configured for ${repo}";
-  hasLocalSources = localRoot != null || localSources != {};
-in {
-  mkLibbitcoin = {
-    pname,
-    repo ? pname,
-    rev,
-    hash,
-    nativeBuildInputs ? [],
-    buildInputs ? [],
-    propagatedBuildInputs ? [],
-    cmakeFlags ? [],
-    patches ? [],
-    patchRoot ? ".",
-    meta ? {},
-  }:
+    else
+      throw "No local source configured for ${repo}";
+  hasLocalSources = localRoot != null || localSources != { };
+in
+{
+  mkLibbitcoin =
+    {
+      pname,
+      repo ? pname,
+      rev,
+      hash,
+      nativeBuildInputs ? [ ],
+      buildInputs ? [ ],
+      propagatedBuildInputs ? [ ],
+      cmakeFlags ? [ ],
+      patches ? [ ],
+      patchRoot ? ".",
+      meta ? { },
+    }:
     buildStdenv.mkDerivation {
       inherit pname version patches;
 
       src =
-        if !hasLocalSources
-        then
+        if !hasLocalSources then
           fetchFromGitHub {
             owner = "libbitcoin";
             inherit repo rev;
             sha256 = hash;
           }
-        else localSource repo;
+        else
+          localSource repo;
 
       sourceRoot = "source/builds/cmake";
 
-      nativeBuildInputs = [cmake] ++ nativeBuildInputs;
-      buildInputs =
-        [boost186 secp256k1 secp256k1CmakeConfig]
-        ++ lib.optionals withUltrafast [ultrafastSecp256k1]
-        ++ buildInputs;
+      nativeBuildInputs = [ cmake ] ++ nativeBuildInputs;
+      buildInputs = [
+        boost186
+        secp256k1
+        secp256k1CmakeConfig
+      ]
+      ++ lib.optionals withUltrafast [ ultrafastSecp256k1 ]
+      ++ buildInputs;
       propagatedBuildInputs = propagatedBuildInputs;
-      NIX_CFLAGS_COMPILE = lib.optionalString (withUltrafast && pname == "libbitcoin-system") "-DWITH_ULTRAFAST";
-      NIX_LDFLAGS = lib.optionalString (withUltrafast && pname == "libbitcoin-system") "-L${ultrafastSecp256k1}/lib -lufsecp";
+      NIX_CFLAGS_COMPILE = lib.optionalString (
+        withUltrafast && pname == "libbitcoin-system"
+      ) "-DWITH_ULTRAFAST";
+      NIX_LDFLAGS = lib.optionalString (
+        withUltrafast && pname == "libbitcoin-system"
+      ) "-L${ultrafastSecp256k1}/lib -lufsecp";
       doCheck = withTests;
-      prePatch =
-        ''
-          chmod -R u+w ${lib.escapeShellArg patchRoot}
-        ''
-        + lib.optionalString (patchRoot != ".") ''
-          pushd ${patchRoot}
-        '';
+      prePatch = ''
+        chmod -R u+w ${lib.escapeShellArg patchRoot}
+      ''
+      + lib.optionalString (patchRoot != ".") ''
+        pushd ${patchRoot}
+      '';
       postPatch = lib.optionalString (patchRoot != ".") ''
         popd
       '';
 
-      cmakeFlags =
-        [
-          "-DBUILD_SHARED_LIBS=ON"
-          "-Dwith-tests=${
-            if withTests
-            then "ON"
-            else "OFF"
-          }"
-        ]
-        ++ lib.optionals withUltrafast ["-Dwith-ultrafast=ON"]
-        ++ cmakeFlags;
+      cmakeFlags = [
+        "-DBUILD_SHARED_LIBS=ON"
+        "-Dwith-tests=${if withTests then "ON" else "OFF"}"
+      ]
+      ++ lib.optionals withUltrafast [ "-Dwith-ultrafast=ON" ]
+      ++ cmakeFlags;
 
       checkPhase = ''
         runHook preCheck
@@ -109,12 +114,11 @@ in {
 
       enableParallelBuilding = true;
 
-      meta =
-        {
-          homepage = "https://github.com/libbitcoin/${repo}";
-          license = lib.licenses.agpl3Plus;
-          platforms = lib.platforms.unix;
-        }
-        // meta;
+      meta = {
+        homepage = "https://github.com/libbitcoin/${repo}";
+        license = lib.licenses.agpl3Plus;
+        platforms = lib.platforms.unix;
+      }
+      // meta;
     };
 }

--- a/pkgs/libbitcoin/database.nix
+++ b/pkgs/libbitcoin/database.nix
@@ -8,7 +8,7 @@ common.mkLibbitcoin {
   rev = "cbc06478121006c570f3d9c0ddb69b3adc3ac20b";
   hash = "0f3my27ly7x0bmf053f6fbh0wqz8yh5g6bs89lp9hkyz3yjig809";
 
-  propagatedBuildInputs = [libbitcoin-system];
+  propagatedBuildInputs = [ libbitcoin-system ];
 
   meta.description = "Memory-mapped blockchain database library for libbitcoin";
 }

--- a/pkgs/libbitcoin/default.nix
+++ b/pkgs/libbitcoin/default.nix
@@ -4,7 +4,7 @@
   secp256k1,
   cudaPackages,
   localRoot ? null,
-  localSources ? {},
+  localSources ? { },
   withCuda ? false,
   enableXcpu ? false,
   withTests ? false,
@@ -13,8 +13,9 @@
   ccacheMaxSize ? "50G",
   cudaArchitectures ? null,
   withUltrafast ? false,
-  systemPatches ? [],
-}: rec {
+  systemPatches ? [ ],
+}:
+rec {
   secp256k1_0_7 = secp256k1.overrideAttrs (_old: rec {
     version = "0.7.0";
     src = fetchFromGitHub {
@@ -29,14 +30,31 @@
     secp256k1 = secp256k1_0_7;
   };
   ultrafastSecp256k1 = callPackage ./ultrafast-secp256k1.nix {
-    inherit cudaPackages withCuda cudaArchitectures useCcache ccacheDir ccacheMaxSize;
+    inherit
+      cudaPackages
+      withCuda
+      cudaArchitectures
+      useCcache
+      ccacheDir
+      ccacheMaxSize
+      ;
   };
   common = callPackage ./common.nix {
     secp256k1 = secp256k1_0_7;
-    inherit ultrafastSecp256k1 secp256k1CmakeConfig localRoot localSources withTests withUltrafast useCcache ccacheDir ccacheMaxSize;
+    inherit
+      ultrafastSecp256k1
+      secp256k1CmakeConfig
+      localRoot
+      localSources
+      withTests
+      withUltrafast
+      useCcache
+      ccacheDir
+      ccacheMaxSize
+      ;
   };
 
-  libbitcoin-system = callPackage ./system.nix {inherit common enableXcpu systemPatches;};
+  libbitcoin-system = callPackage ./system.nix { inherit common enableXcpu systemPatches; };
   libbitcoin-database = callPackage ./database.nix {
     inherit common libbitcoin-system;
   };

--- a/pkgs/libbitcoin/default.nix
+++ b/pkgs/libbitcoin/default.nix
@@ -40,10 +40,8 @@ rec {
       ;
   };
   common = callPackage ./common.nix {
-    secp256k1 = secp256k1_0_7;
     inherit
       ultrafastSecp256k1
-      secp256k1CmakeConfig
       localRoot
       localSources
       withTests
@@ -54,7 +52,15 @@ rec {
       ;
   };
 
-  libbitcoin-system = callPackage ./system.nix { inherit common enableXcpu systemPatches; };
+  libbitcoin-system = callPackage ./system.nix {
+    secp256k1 = secp256k1_0_7;
+    inherit
+      common
+      secp256k1CmakeConfig
+      enableXcpu
+      systemPatches
+      ;
+  };
   libbitcoin-database = callPackage ./database.nix {
     inherit common libbitcoin-system;
   };

--- a/pkgs/libbitcoin/network.nix
+++ b/pkgs/libbitcoin/network.nix
@@ -8,7 +8,7 @@ common.mkLibbitcoin {
   rev = "0450a00c55709ebe369eb5751dc3b3bf0b65d924";
   hash = "0hprpx5pim1c3sf35wp2c8p6z8hywmaqkskq1m0n3sw2s69zzfr2";
 
-  propagatedBuildInputs = [libbitcoin-system];
+  propagatedBuildInputs = [ libbitcoin-system ];
 
   meta.description = "Bitcoin P2P networking library for libbitcoin";
 }

--- a/pkgs/libbitcoin/node.nix
+++ b/pkgs/libbitcoin/node.nix
@@ -9,8 +9,11 @@ common.mkLibbitcoin {
   rev = "6a765df6fa8ddbc582371956681f3efe30bcb2a8";
   hash = "0zcl1s4w5dpk9mlha274d5x88f85gby7l0ys0dmqg25q1hwj924q";
 
-  propagatedBuildInputs = [libbitcoin-database libbitcoin-network];
-  cmakeFlags = ["-Dwith-console=ON"];
+  propagatedBuildInputs = [
+    libbitcoin-database
+    libbitcoin-network
+  ];
+  cmakeFlags = [ "-Dwith-console=ON" ];
 
   meta.description = "Bitcoin full node library and console for libbitcoin";
   meta.mainProgram = "bn";

--- a/pkgs/libbitcoin/secp256k1-cmake-config.nix
+++ b/pkgs/libbitcoin/secp256k1-cmake-config.nix
@@ -4,39 +4,41 @@
   runCommand,
   secp256k1,
 }:
-runCommand "libsecp256k1-cmake-config-${secp256k1.version}" {
-  meta = {
-    description = "CMake package config shim for nixpkgs secp256k1";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
-  };
-} ''
-  configDir="$out/lib/cmake/libsecp256k1"
-  mkdir -p "$configDir"
+runCommand "libsecp256k1-cmake-config-${secp256k1.version}"
+  {
+    meta = {
+      description = "CMake package config shim for nixpkgs secp256k1";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+    };
+  }
+  ''
+    configDir="$out/lib/cmake/libsecp256k1"
+    mkdir -p "$configDir"
 
-  cat > "$configDir/libsecp256k1-config.cmake" <<'EOF'
-  if(NOT TARGET libsecp256k1::secp256k1)
-    add_library(libsecp256k1::secp256k1 UNKNOWN IMPORTED)
-    set_target_properties(libsecp256k1::secp256k1 PROPERTIES
-      IMPORTED_LOCATION "${secp256k1}/lib/libsecp256k1${stdenv.hostPlatform.extensions.sharedLibrary}"
-      INTERFACE_INCLUDE_DIRECTORIES "${secp256k1}/include"
-    )
-  endif()
+    cat > "$configDir/libsecp256k1-config.cmake" <<'EOF'
+    if(NOT TARGET libsecp256k1::secp256k1)
+      add_library(libsecp256k1::secp256k1 UNKNOWN IMPORTED)
+      set_target_properties(libsecp256k1::secp256k1 PROPERTIES
+        IMPORTED_LOCATION "${secp256k1}/lib/libsecp256k1${stdenv.hostPlatform.extensions.sharedLibrary}"
+        INTERFACE_INCLUDE_DIRECTORIES "${secp256k1}/include"
+      )
+    endif()
 
-  set(libsecp256k1_VERSION "${secp256k1.version}")
-  set(libsecp256k1_FOUND TRUE)
-  EOF
+    set(libsecp256k1_VERSION "${secp256k1.version}")
+    set(libsecp256k1_FOUND TRUE)
+    EOF
 
-  cat > "$configDir/libsecp256k1-config-version.cmake" <<'EOF'
-  set(PACKAGE_VERSION "${secp256k1.version}")
+    cat > "$configDir/libsecp256k1-config-version.cmake" <<'EOF'
+    set(PACKAGE_VERSION "${secp256k1.version}")
 
-  if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
-    set(PACKAGE_VERSION_EXACT TRUE)
-    set(PACKAGE_VERSION_COMPATIBLE TRUE)
-  elseif(PACKAGE_FIND_VERSION VERSION_LESS PACKAGE_VERSION)
-    set(PACKAGE_VERSION_COMPATIBLE TRUE)
-  else()
-    set(PACKAGE_VERSION_COMPATIBLE FALSE)
-  endif()
-  EOF
-''
+    if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+      set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    elseif(PACKAGE_FIND_VERSION VERSION_LESS PACKAGE_VERSION)
+      set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    else()
+      set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    endif()
+    EOF
+  ''

--- a/pkgs/libbitcoin/server.nix
+++ b/pkgs/libbitcoin/server.nix
@@ -8,8 +8,8 @@ common.mkLibbitcoin {
   rev = "1df3db4a653ca56a8785093bc7facee4996796b0";
   hash = "1dqxqrw2m8skb822wb3nrh93l8731xjmf80xycf097pa7nr79gm9";
 
-  propagatedBuildInputs = [libbitcoin-node];
-  cmakeFlags = ["-Dwith-console=ON"];
+  propagatedBuildInputs = [ libbitcoin-node ];
+  cmakeFlags = [ "-Dwith-console=ON" ];
 
   meta.description = "High performance Bitcoin full node query server";
   meta.mainProgram = "bs";

--- a/pkgs/libbitcoin/system.nix
+++ b/pkgs/libbitcoin/system.nix
@@ -2,7 +2,7 @@
   common,
   lib,
   enableXcpu ? false,
-  systemPatches ? [],
+  systemPatches ? [ ],
 }:
 common.mkLibbitcoin {
   pname = "libbitcoin-system";
@@ -10,16 +10,14 @@ common.mkLibbitcoin {
   rev = "b4821a37afc4b79c1c4b92d9d4a47bae84c3c881";
   hash = "0h88sx349r915lpbfcw3w8x604v11yxfx41y6ri76cdhfjgfx6wz";
   patches = systemPatches;
-  patchRoot =
-    if systemPatches != []
-    then "../.."
-    else ".";
-  cmakeFlags =
-    ["-Dwith-examples=OFF"]
-    ++ lib.optionals enableXcpu [
-      "-Denable-avx2=ON"
-      "-Denable-shani=ON"
-    ];
+  patchRoot = if systemPatches != [ ] then "../.." else ".";
+  cmakeFlags = [
+    "-Dwith-examples=OFF"
+  ]
+  ++ lib.optionals enableXcpu [
+    "-Denable-avx2=ON"
+    "-Denable-shani=ON"
+  ];
 
   meta.description = "Foundational C++ library for the libbitcoin toolkit";
 }

--- a/pkgs/libbitcoin/system.nix
+++ b/pkgs/libbitcoin/system.nix
@@ -1,6 +1,9 @@
 {
   common,
   lib,
+  boost186,
+  secp256k1,
+  secp256k1CmakeConfig,
   enableXcpu ? false,
   systemPatches ? [ ],
 }:
@@ -17,6 +20,11 @@ common.mkLibbitcoin {
   ++ lib.optionals enableXcpu [
     "-Denable-avx2=ON"
     "-Denable-shani=ON"
+  ];
+  propagatedBuildInputs = [
+    boost186
+    secp256k1
+    secp256k1CmakeConfig
   ];
 
   meta.description = "Foundational C++ library for the libbitcoin toolkit";

--- a/pkgs/libbitcoin/ultrafast-secp256k1.nix
+++ b/pkgs/libbitcoin/ultrafast-secp256k1.nix
@@ -10,11 +10,11 @@
   useCcache ? false,
   ccacheDir ? "/var/cache/ccache",
   ccacheMaxSize ? "50G",
-}: let
+}:
+let
   version = "dev-caba608d";
   buildStdenv =
-    if useCcache
-    then
+    if useCcache then
       ccacheStdenv.override {
         extraConfig = ''
           export CCACHE_COMPRESS=1
@@ -23,138 +23,135 @@
           export CCACHE_UMASK=007
         '';
       }
-    else stdenv;
+    else
+      stdenv;
 in
-  buildStdenv.mkDerivation {
-    pname = "ultrafast-secp256k1";
-    inherit version;
+buildStdenv.mkDerivation {
+  pname = "ultrafast-secp256k1";
+  inherit version;
 
-    src = fetchFromGitHub {
-      owner = "shrec";
-      repo = "UltrafastSecp256k1";
-      rev = "caba608d7ee0226ac8060fe057df8fbbdad3838e";
-      hash = "sha256-eaOAndl9CC0dKbO30OZsybK6LzvgP5euEbGPde8+EPQ=";
-    };
+  src = fetchFromGitHub {
+    owner = "shrec";
+    repo = "UltrafastSecp256k1";
+    rev = "caba608d7ee0226ac8060fe057df8fbbdad3838e";
+    hash = "sha256-eaOAndl9CC0dKbO30OZsybK6LzvgP5euEbGPde8+EPQ=";
+  };
 
-    patches = [
-      ./patches/ultrafast-cuda-field-inv-launch-bounds.patch
-      ./patches/ultrafast-libbitcoin-streaming-gpu.patch
-      ./patches/ultrafast-libbitcoin-bridge-status-propagation.patch
-      ./patches/ultrafast-cuda-column-offsets-64bit.patch
-      ./patches/ultrafast-cuda-columnar-schnorr-fast-path.patch
-    ];
+  patches = [
+    ./patches/ultrafast-cuda-field-inv-launch-bounds.patch
+    ./patches/ultrafast-libbitcoin-streaming-gpu.patch
+    ./patches/ultrafast-libbitcoin-bridge-status-propagation.patch
+    ./patches/ultrafast-cuda-column-offsets-64bit.patch
+    ./patches/ultrafast-cuda-columnar-schnorr-fast-path.patch
+  ];
 
-    nativeBuildInputs =
-      [cmake]
-      ++ lib.optionals (withCuda && cudaPackages != null) [
-        cudaPackages.cuda_nvcc
-      ];
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals (withCuda && cudaPackages != null) [
+    cudaPackages.cuda_nvcc
+  ];
 
-    buildInputs = lib.optionals (withCuda && cudaPackages != null) [
-      cudaPackages.cuda_cudart
-    ];
+  buildInputs = lib.optionals (withCuda && cudaPackages != null) [
+    cudaPackages.cuda_cudart
+  ];
 
-    cmakeFlags =
-      [
-        "-DCMAKE_INSTALL_LIBDIR=lib"
-        "-DCMAKE_INSTALL_INCLUDEDIR=include"
-        "-DSECP256K1_BUILD_LIBBITCOIN=OFF"
-        "-DSECP256K1_BUILD_LIBBITCOIN_BRIDGE=ON"
-        "-DSECP256K1_BUILD_CPU=ON"
-        "-DSECP256K1_BUILD_CUDA=${
-          if withCuda
-          then "ON"
-          else "OFF"
-        }"
-        "-DSECP256K1_BUILD_ROCM=OFF"
-        "-DSECP256K1_BUILD_OPENCL=OFF"
-        "-DSECP256K1_BUILD_METAL=OFF"
-        "-DSECP256K1_BUILD_TESTS=OFF"
-        "-DSECP256K1_BUILD_BENCH=OFF"
-        "-DSECP256K1_BUILD_EXAMPLES=OFF"
-        "-DSECP256K1_BUILD_JAVA=OFF"
-        "-DSECP256K1_BUILD_CABI=ON"
-        "-DSECP256K1_INSTALL_CABI=ON"
-        "-DUFSECP_LBTC_BUILD_TESTS=OFF"
-        "-DUFSECP_LBTC_BUILD_EXAMPLE=OFF"
-        "-DUFSECP_LBTC_BUILD_BENCH=OFF"
-        "-DSECP256K1_INSTALL=OFF"
-        "-DSECP256K1_INSTALL_PKGCONFIG=OFF"
-      ]
-      ++ lib.optionals (withCuda && cudaArchitectures != null) [
-        "-DCMAKE_CUDA_ARCHITECTURES=${cudaArchitectures}"
-      ];
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DSECP256K1_BUILD_LIBBITCOIN=OFF"
+    "-DSECP256K1_BUILD_LIBBITCOIN_BRIDGE=ON"
+    "-DSECP256K1_BUILD_CPU=ON"
+    "-DSECP256K1_BUILD_CUDA=${if withCuda then "ON" else "OFF"}"
+    "-DSECP256K1_BUILD_ROCM=OFF"
+    "-DSECP256K1_BUILD_OPENCL=OFF"
+    "-DSECP256K1_BUILD_METAL=OFF"
+    "-DSECP256K1_BUILD_TESTS=OFF"
+    "-DSECP256K1_BUILD_BENCH=OFF"
+    "-DSECP256K1_BUILD_EXAMPLES=OFF"
+    "-DSECP256K1_BUILD_JAVA=OFF"
+    "-DSECP256K1_BUILD_CABI=ON"
+    "-DSECP256K1_INSTALL_CABI=ON"
+    "-DUFSECP_LBTC_BUILD_TESTS=OFF"
+    "-DUFSECP_LBTC_BUILD_EXAMPLE=OFF"
+    "-DUFSECP_LBTC_BUILD_BENCH=OFF"
+    "-DSECP256K1_INSTALL=OFF"
+    "-DSECP256K1_INSTALL_PKGCONFIG=OFF"
+  ]
+  ++ lib.optionals (withCuda && cudaArchitectures != null) [
+    "-DCMAKE_CUDA_ARCHITECTURES=${cudaArchitectures}"
+  ];
 
-    buildPhase = ''
-      runHook preBuild
-      cmake --build . --target ufsecp_static --parallel $NIX_BUILD_CORES
-      cmake --build . --target ufsecp_shared --parallel $NIX_BUILD_CORES
-      runHook postBuild
-    '';
+  buildPhase = ''
+    runHook preBuild
+    cmake --build . --target ufsecp_static --parallel $NIX_BUILD_CORES
+    cmake --build . --target ufsecp_shared --parallel $NIX_BUILD_CORES
+    runHook postBuild
+  '';
 
-    installPhase = ''
-      runHook preInstall
-      mkdir -p "$out/include/ufsecp" "$out/lib" "$out/lib/cmake/secp256k1-fast"
-      chmod -R u+w "$out/include/ufsecp" "$out/lib" 2>/dev/null || true
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/include/ufsecp" "$out/lib" "$out/lib/cmake/secp256k1-fast"
+    chmod -R u+w "$out/include/ufsecp" "$out/lib" 2>/dev/null || true
 
-      if [ -f compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h ]; then
-        cp compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
-          "$out/include/ufsecp_libbitcoin.h"
-        cp compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
-          "$out/include/ufsecp/ufsecp_libbitcoin.h"
-      else
-        cp ../compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
-          "$out/include/ufsecp_libbitcoin.h"
-        cp ../compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
-          "$out/include/ufsecp/ufsecp_libbitcoin.h"
-      fi
+    if [ -f compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h ]; then
+      cp compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
+        "$out/include/ufsecp_libbitcoin.h"
+      cp compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
+        "$out/include/ufsecp/ufsecp_libbitcoin.h"
+    else
+      cp ../compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
+        "$out/include/ufsecp_libbitcoin.h"
+      cp ../compat/libbitcoin_bridge/include/ufsecp_libbitcoin.h \
+        "$out/include/ufsecp/ufsecp_libbitcoin.h"
+    fi
 
-      if [ -d ../compat/libbitcoin_direct/include/ufsecp ]; then
-        cp -f ../compat/libbitcoin_direct/include/ufsecp/*.hpp "$out/include/ufsecp/"
-      elif [ -d compat/libbitcoin_direct/include/ufsecp ]; then
-        cp -f compat/libbitcoin_direct/include/ufsecp/*.hpp "$out/include/ufsecp/"
-      fi
+    if [ -d ../compat/libbitcoin_direct/include/ufsecp ]; then
+      cp -f ../compat/libbitcoin_direct/include/ufsecp/*.hpp "$out/include/ufsecp/"
+    elif [ -d compat/libbitcoin_direct/include/ufsecp ]; then
+      cp -f compat/libbitcoin_direct/include/ufsecp/*.hpp "$out/include/ufsecp/"
+    fi
 
-      if [ -d ../include/ufsecp ]; then
-        cp -f ../include/ufsecp/*.h "$out/include/ufsecp/"
-      else
-        cp -f include/ufsecp/*.h "$out/include/ufsecp/"
-      fi
-      cp -f include/ufsecp/ufsecp_version.h "$out/include/ufsecp/"
+    if [ -d ../include/ufsecp ]; then
+      cp -f ../include/ufsecp/*.h "$out/include/ufsecp/"
+    else
+      cp -f include/ufsecp/*.h "$out/include/ufsecp/"
+    fi
+    cp -f include/ufsecp/ufsecp_version.h "$out/include/ufsecp/"
 
-      if [ -f include/ufsecp/libufsecp.a ]; then
-        cp include/ufsecp/libufsecp.a "$out/lib/libufsecp.a"
-      elif [ -f include/ufsecp/libufsecp_s.a ]; then
-        cp include/ufsecp/libufsecp_s.a "$out/lib/libufsecp.a"
-      fi
+    if [ -f include/ufsecp/libufsecp.a ]; then
+      cp include/ufsecp/libufsecp.a "$out/lib/libufsecp.a"
+    elif [ -f include/ufsecp/libufsecp_s.a ]; then
+      cp include/ufsecp/libufsecp_s.a "$out/lib/libufsecp.a"
+    fi
 
-      find include/ufsecp -maxdepth 1 -name 'libufsecp.so*' \
-        -exec cp -P {} "$out/lib/" \;
+    find include/ufsecp -maxdepth 1 -name 'libufsecp.so*' \
+      -exec cp -P {} "$out/lib/" \;
 
-      cat > "$out/lib/cmake/secp256k1-fast/secp256k1-fast-config.cmake" <<EOF
-      if (NOT TARGET secp256k1::fastsecp256k1)
-        add_library(secp256k1::fastsecp256k1 SHARED IMPORTED)
-        set_target_properties(secp256k1::fastsecp256k1 PROPERTIES
-          IMPORTED_LOCATION "$out/lib/libufsecp.so"
-          INTERFACE_INCLUDE_DIRECTORIES "$out/include"
-        )
-      endif()
+    cat > "$out/lib/cmake/secp256k1-fast/secp256k1-fast-config.cmake" <<EOF
+    if (NOT TARGET secp256k1::fastsecp256k1)
+      add_library(secp256k1::fastsecp256k1 SHARED IMPORTED)
+      set_target_properties(secp256k1::fastsecp256k1 PROPERTIES
+        IMPORTED_LOCATION "$out/lib/libufsecp.so"
+        INTERFACE_INCLUDE_DIRECTORIES "$out/include"
+      )
+    endif()
 
-      set(secp256k1-fast_FOUND TRUE)
-      EOF
+    set(secp256k1-fast_FOUND TRUE)
+    EOF
 
-      cat > "$out/lib/cmake/secp256k1-fast/secp256k1-fast-config-version.cmake" <<EOF
-      set(PACKAGE_VERSION "4.4.0.0")
-      set(PACKAGE_VERSION_COMPATIBLE TRUE)
-      set(PACKAGE_VERSION_EXACT FALSE)
-      EOF
-      runHook postInstall
-    '';
+    cat > "$out/lib/cmake/secp256k1-fast/secp256k1-fast-config-version.cmake" <<EOF
+    set(PACKAGE_VERSION "4.4.0.0")
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    set(PACKAGE_VERSION_EXACT FALSE)
+    EOF
+    runHook postInstall
+  '';
 
-    meta = {
-      homepage = "https://github.com/shrec/UltrafastSecp256k1";
-      description = "Ultrafast secp256k1 library with libbitcoin bridge";
-      license = lib.licenses.mit;
-      platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    };
-  }
+  meta = {
+    homepage = "https://github.com/shrec/UltrafastSecp256k1";
+    description = "Ultrafast secp256k1 library with libbitcoin bridge";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,7 +1,0 @@
-{
-  projectRootFile = "flake.nix";
-
-  programs.alejandra.enable = true;
-
-  settings.formatter.alejandra.includes = ["*.nix"];
-}


### PR DESCRIPTION
- Use nixfmt-tree for formatting (no config, "official" formatter)
- propagate inputs a bit more cleanly from base libbitcoin
- make flake outputs (a bit) more ergonomic, use `app` so `nix run` just works (tm).

Built, but not run-tested.